### PR TITLE
Fix c.executemany when populating a created table

### DIFF
--- a/termsql
+++ b/termsql
@@ -354,7 +354,7 @@ if args.offset_tail and int(args.offset_tail) > 0: #remove all the entries from 
 
 if max_count > 0:
     #execute inserts, fill table with row data
-    c.executemany('insert into tbl values ('+placeholder_str+')', inserts)
+    c.executemany('insert into '+table_name+' values ('+placeholder_str+')', inserts)
     conn.commit()
 
 


### PR DESCRIPTION
On line 357, Replaced placeholder text of "tbl" with " '+table_name+' " to fix  #1 
