### PR TITLE
updates for -c args.

### DIFF
--- a/termsql
+++ b/termsql
@@ -61,6 +61,7 @@ delimiter = ' '
 separator = '' #default to whatever sqlite defaults to
 mode = 'list'
 columns = ''
+cols = ''
 key_columns = ''
 offset_head = 0
 max_rows = 0
@@ -177,6 +178,7 @@ if args.key_columns:
     key_columns = [x.strip() for x in args.key_columns.split(',')]
 if args.columns:
     columns = [x.strip() for x in args.columns.split(',')]
+    cols = args.columns
 if args.offset_head:
     offset_head = args.offset_head
 if args.queryfile:
@@ -366,7 +368,10 @@ if args.offset_tail and int(args.offset_tail) > 0: #remove all the entries from 
 
 if max_count > 0:
     #execute inserts, fill table with row data
-    c.executemany('insert into '+table_name+' values ('+placeholder_str+')', inserts)
+    if len(cols) > 0:
+        c.executemany('insert into '+table_name+'('+cols+') values ('+placeholder_str+')', inserts)
+    else:
+        c.executemany('insert into '+table_name+' values ('+placeholder_str+')', inserts)
     conn.commit()
 
 


### PR DESCRIPTION
When a user specifies the columns with the -c arg, should use those columns for the inserts.

For example, I have a table that I created before running termsql.  

DROP TABLE IF EXISTS "shapes_tmp";
CREATE TABLE "shapes_tmp"
(
  shape_key integer primary key autoincrement,
  shape_id text,
  shape_pt_lat double precision,
  shape_pt_lon double precision,
  shape_pt_sequence integer,
  shape_dist_traveled double precision
);

And if I run termsql with the -a and -c option, it will not work as sqlite3 sees shape_key as an extra column.  (notice no shape_key column in the cmd) 

termsql -a -i ./shapes.txt -c 'shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence,shape_dist_traveled' -1 -d '|' -t shapes_tmp -o transit.sqlite

Traceback (most recent call last):
  File "./termsql.old/termsql", line 369, in <module>
    c.executemany('insert into '+table_name+' values ('+placeholder_str+')', inserts)
sqlite3.OperationalError: table shapes_tmp has 6 columns but 5 values were supplied

insert into '+table_name+'('+cols+') values ('+placeholder_str+')' will fix this issue.  

Basically performing:  
    INSERT INTO table_name (column1, column2, column3,...)
    VALUES (value1, value2, value3,...)
